### PR TITLE
Specify bids can only be made in whole values

### DIFF
--- a/src/routes/(app)/auctions/[id]/+page.svelte
+++ b/src/routes/(app)/auctions/[id]/+page.svelte
@@ -16,7 +16,7 @@
 	$: auction = data.auction.product;
 	$: images = data.auction.images;
 	$: bidAmount = data.bids.length;
-	$: priceIncrease = Math.round((auction.price * 1.1 + Number.EPSILON) * 100) / 100;
+	$: priceIncrease = data.priceIncrease;
 </script>
 
 <section class="flex flex-col gap-12 md:flex-row md:gap-24">

--- a/src/routes/(app)/auctions/[id]/bid-modal.svelte
+++ b/src/routes/(app)/auctions/[id]/bid-modal.svelte
@@ -7,7 +7,7 @@
 	export let form;
 	export let priceIncrease: number;
 
-	const formattedPriceIncrease = new Intl.NumberFormat('pt-PT', {
+	$: formattedPriceIncrease = new Intl.NumberFormat('pt-PT', {
 		style: 'currency',
 		currency: 'EUR'
 	}).format(priceIncrease);
@@ -22,7 +22,8 @@
 			<Dialog.Header>
 				<Dialog.Title>Place your Bid</Dialog.Title>
 				<Dialog.Description>
-					By making a Bid, you are commited to buy this item if you are the winning bidder.
+					By making a Bid, you are commited to buy this item if you are the winning bidder. Bids can
+					only be made in EUR, and cents will be cut from the bid.
 				</Dialog.Description>
 			</Dialog.Header>
 			<Form.Field {form} name="value">


### PR DESCRIPTION
Since cents were being truncated without an obvious solution that can work in several places, and given the nature of these deals being in the several euros, removing cents from bidding altogether made the most sense.

Even though it would be possible to parse them using regex or other methods, handling international values could once again complicate these matters. This way simplifies the flow tremendously.